### PR TITLE
fix python example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,17 @@ agent = kerlym.agents.DQN(
                     nframes=1, 
                     epsilon=0.5, 
                     discount=0.99, 
-                    modelfactory=kerlym.networks.simple_cnn,
+                    modelfactory=kerlym.dqn.networks.simple_cnn,
                     batch_size=32, 
                     dropout=0.1, 
                     enable_plots = True, 
                     epsilon_schedule=lambda episode,epsilon: max(0.1, epsilon*(1-1e-4)),                
                     dufference_obs = True,
                     preprocessor = kerlym.preproc.karpathy_preproc,
-                    learning_rate = 1e-4
+                    learning_rate = 1e-4, 
+                    render=True
                     )
-agent.learn()
+agent.train()
 ```
 
 # Custom Action-Value Function Network


### PR DESCRIPTION
Example code in `README.md` doesn't work "as is" with KeRLym==0.0.2.

There are 2 problems:
* `TypeError: 'Model' object is not iterable` error in `DQN.setup_graphs()` function. It is caused by using `kerlym.networks.simple_cnn` instead of `kerlym.dqn.networks.simple_cnn` as a `modelfactory`. They return different values (only model in first case, state&model tuple in second) and `DQN` class expects a tuple.
* `AttributeError: DQN instance has no attribute 'learn'` - probably caused by interface change (`D2QN` in `kerlym/dqn_old.py` has a method named `learn()`, but `DQN` in `kerlym/dqn/dqn.py` has only `train()` which is probably a replacement)

Other issues:
* No rendering by default - this is minor, but still it should be enabled to be consistent with `run_spaceinvaders.sh` example.

Proposed pull request fixes these issues and allows using python script from `README.md` without any modifications.